### PR TITLE
add cyrillic support, also tests for it

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,8 @@
 
 'use strict';
 
-
-// Split the text into an array of words
-var wordArray = function (str) {
-  return str.split(/[\s]+/).filter(Boolean);
-};
-
-module.exports = function wordcount(str) {
-  return wordArray(str).length;
+module.exports = function wordCount(content) {
+  var matches = content.match(/[\u0400-\u04FF]+|\w+/g);
+  var count = matches !== null ? matches.length : 0;
+  return count;
 };

--- a/package.json
+++ b/package.json
@@ -24,18 +24,19 @@
     "count",
     "word",
     "words",
-    "string"
+    "string",
+    "cyrillic"
   ],
   "main": "index.js",
   "engines": {
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "mocha -R spec"
+    "test": "mocha -R spec -r should"
   },
   "devDependencies": {
     "verb": "~0.2.6",
-    "chai": "~1.9.1",
+    "should": "*",
     "mocha": "*"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -5,15 +5,27 @@
  * Licensed under the MIT License
  */
 
-var expect = require('chai').expect;
 var wordcount = require('../');
 
-it('should count the words in a string.', function () {
-  var actual = wordcount('Count the words in string.');
-  expect(actual).to.eql(5);
+describe('wordcount', function() {
+  it('should count the words in a string.', function () {
+    var actual = wordcount('Count the words in string.');
+    actual.should.eql(5)
+  });
+
+  it('should count the words in a string.', function () {
+    var actual = wordcount('Count the words in string, again.');
+    actual.should.eql(6)
+  });
+
+  it('should count the words in a cyrillic string.', function () {
+    var actual = wordcount('Тест стринг кирилица.');
+    actual.should.eql(3)
+  });
+
+  it('should count the words in a mixed string (latin and cyrillic).', function () {
+    var actual = wordcount('Тест mixed стринг кирилица and latin string.');
+    actual.should.eql(7)
+  });
 });
 
-it('should count the words in a string.', function () {
-  var actual = wordcount('Count the words in string, again.');
-  expect(actual).to.eql(6);
-});


### PR DESCRIPTION
- full refactor
- fix old regex bug that I previously suggest at `assemble-middleware-wordcount`, counting +1 when have cyrillic symbols
- change chai with should
- add tests for cyrillic support

fix #1 
